### PR TITLE
Support keyword arguments for open calls

### DIFF
--- a/mock_open.py
+++ b/mock_open.py
@@ -35,6 +35,7 @@ except ImportError:  # pragma: no cover
 
 class NotMocked(Exception):
     """Raised when a file was opened which was not mocked"""
+
     def __init__(self, filename):
         super().__init__(f"The file {filename} was opened, but not mocked.")
         self.filename = filename
@@ -80,7 +81,7 @@ def mock_open(filename, contents=None, exception=None, complain=True):
         open_files.add(file_.name)
         return file_
 
-    mocked_file = mock.patch('builtins.open', mock_file)
+    mocked_file = mock.patch("builtins.open", mock_file)
     mocked_file.start()
     try:
         yield

--- a/mock_open.py
+++ b/mock_open.py
@@ -61,7 +61,7 @@ def mock_open(filename, contents=None, exception=None, complain=True):
     """
     open_files = set()
 
-    def mock_file(*args):
+    def mock_file(*args, **kwargs):
         """Mocked open() function
 
         Takes the same arguments as the open() function.
@@ -75,7 +75,7 @@ def mock_open(filename, contents=None, exception=None, complain=True):
                 raise exception  # false positive; pylint: disable=raising-bad-type
         else:
             mocked_file.stop()
-            file_ = open(*args)
+            file_ = open(*args, **kwargs)
             mocked_file.start()
         open_files.add(file_.name)
         return file_

--- a/mock_open.py
+++ b/mock_open.py
@@ -36,8 +36,7 @@ except ImportError:  # pragma: no cover
 class NotMocked(Exception):
     """Raised when a file was opened which was not mocked"""
     def __init__(self, filename):
-        super(NotMocked, self).__init__(
-            "The file %s was opened, but not mocked." % filename)
+        super().__init__(f"The file {filename} was opened, but not mocked.")
         self.filename = filename
 
 
@@ -75,6 +74,7 @@ def mock_open(filename, contents=None, exception=None, complain=True):
                 raise exception  # false positive; pylint: disable=raising-bad-type
         else:
             mocked_file.stop()
+            # pylint: disable=consider-using-with,unspecified-encoding
             file_ = open(*args, **kwargs)
             mocked_file.start()
         open_files.add(file_.name)
@@ -90,9 +90,9 @@ def mock_open(filename, contents=None, exception=None, complain=True):
     mocked_file.stop()
     try:
         open_files.remove(filename)
-    except KeyError:
+    except KeyError as error:
         if complain:
-            raise AssertionError("The file %s was not opened." % filename)
+            raise AssertionError(f"The file {filename} was not opened.") from error
     for f_name in open_files:
         if complain:
             raise NotMocked(f_name)

--- a/mock_open.py
+++ b/mock_open.py
@@ -1,7 +1,7 @@
 # The MIT License (MIT)
 
 # Copyright (c) 2013 Ionuț Arțăriși <ionut@artarisi.eu>
-#               2018 Benjamin Drung <benjamin.drung@profitbricks.com>
+#               2018-2022 Benjamin Drung <bdrung@posteo.de>
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/test_mock_open.py
+++ b/test_mock_open.py
@@ -64,13 +64,13 @@ class MockTest(unittest.TestCase):
         with self.assertRaises(NotMocked):
             with mock_open("file1", "foo"):
                 with mock_open("file2", "foo"):
-                    with open(__file__):
-                        with open("file1") as mocked_file1:
-                            with open("file2") as mocked_file2:
+                    with open(__file__, encoding="utf-8"):
+                        with open("file1", encoding="utf-8") as mocked_file1:
+                            with open("file2", encoding="utf-8") as mocked_file2:
                                 self.assertEqual(mocked_file1.read(), mocked_file2.read())
 
     def test_raise_exception(self):
         """Test raising an exception on mocked open()"""
         with self.assertRaises(PermissionError):
             with mock_open("file", exception=PermissionError(13, "Permission denied")):
-                open("file")
+                open("file", encoding="utf-8")  # pylint: disable=consider-using-with

--- a/test_mock_open.py
+++ b/test_mock_open.py
@@ -35,6 +35,7 @@ from mock_open import NotMocked, mock_open
 
 class OrderedSet(collections.UserList):  # pylint: disable=too-many-ancestors
     """set subclass that remembers the order entries were added"""
+
     def add(self, element):
         """Add given element to set"""
         if element not in self.data:
@@ -43,6 +44,7 @@ class OrderedSet(collections.UserList):  # pylint: disable=too-many-ancestors
 
 class MockTest(unittest.TestCase):
     """Test mock_open()"""
+
     def test_open_same_file_twice(self):
         """Test opening the same mocked file twice"""
         with mock_open("test_file", "foo"):

--- a/test_mock_open.py
+++ b/test_mock_open.py
@@ -46,8 +46,8 @@ class MockTest(unittest.TestCase):
     def test_open_same_file_twice(self):
         """Test opening the same mocked file twice"""
         with mock_open("test_file", "foo"):
-            with open("test_file") as first:
-                with open("test_file") as second:
+            with open("test_file", encoding="utf-8") as first:
+                with open("test_file", encoding="utf-8") as second:
                     self.assertEqual(first.read(), second.read())
                     first.seek(0)
                     self.assertEqual("foo", first.read())


### PR DESCRIPTION
The `open` function takes keyword arguments like `encoding`. Mocking those calls fails:

```
======================================================================
ERROR: test_open_same_file_twice (test_mock_open.MockTest)
Test opening the same mocked file twice
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mock_open.py", line 49, in test_open_same_file_twice
    with open("test_file", encoding="utf-8") as first:
TypeError: mock_file() got an unexpected keyword argument 'encoding'
```

Also address issues found by pylint 2.12.2:

```
************* Module mock_open
mock_open.py:39:8: R1725: Consider using Python 3 style super() without arguments (super-with-arguments)
mock_open.py:40:12: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
mock_open.py:78:20: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
mock_open.py:78:20: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
mock_open.py:95:12: W0707: Consider explicitly re-raising using the 'from' keyword (raise-missing-from)
mock_open.py:95:33: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module test_mock_open
test_mock_open.py:49:17: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
test_mock_open.py:50:21: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
test_mock_open.py:67:25: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
test_mock_open.py:68:29: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
test_mock_open.py:69:33: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
test_mock_open.py:76:16: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
test_mock_open.py:76:16: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
```